### PR TITLE
Remove '-fcatch-undefined-behavior' CFLAGS

### DIFF
--- a/ObjectiveGitFramework.xcodeproj/project.pbxproj
+++ b/ObjectiveGitFramework.xcodeproj/project.pbxproj
@@ -1838,7 +1838,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				OTHER_CFLAGS = (
-					"$(inherited)",
+					"-ftrapv",
 					"-DGIT_SSH",
 				);
 				TEST_AFTER_BUILD = NO;


### PR DESCRIPTION
The lastest clang has deprecated '-fcatch-undefined-behavior' CFLAG.
And now it not only a warning, but a really error, so just fix it.
